### PR TITLE
Add Sign Language To Unique Tongues

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -157,7 +157,9 @@
 		/datum/language/common,
 		/datum/language/draconic,
 		/datum/language/ratvar,
-		/datum/language/monkey))
+		/datum/language/monkey,
+		/datum/language/signlanguage, // Lumos Change
+	))
 
 /obj/item/organ/tongue/alien/Initialize(mapload)
 	. = ..()
@@ -265,6 +267,7 @@
 		/datum/language/sylvan,
 		/datum/language/voltaic,
 		/datum/language/neokanji,
+		/datum/language/signlanguage, // Lumos Change
 	))
 
 /obj/item/organ/tongue/ethereal/Initialize(mapload)
@@ -284,6 +287,7 @@
 		/datum/language/beachbum,
 		/datum/language/aphasia,
 		/datum/language/arachnid,
+		/datum/language/signlanguage, // Lumos Change
 	))
 
 /obj/item/organ/tongue/arachnid/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Adds sign language to unique languages_possible lists. Not sure if something was just broken with how language lists were implemented but this should fix this language being missed at least. Might just have to add everything to the unique lists at some point.

## Why It's Good For The Game

Sign language should be possible for all species with working hands.

## Changelog
:cl:
add: Added sign language to alien, ethereal and arachnid tongues.
/:cl:
