### PR TITLE
Adds Separated Chems to Glow Berries

### DIFF
--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -91,7 +91,7 @@
 	lifespan = 30
 	endurance = 25
 	mutatelist = list()
-	genes = list(/datum/plant_gene/trait/glow/white, /datum/plant_gene/trait/repeated_harvest)
+	genes = list(/datum/plant_gene/trait/glow/white, /datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/noreact) //Lumos Change -- Separated Chems
 	reagents_add = list(/datum/reagent/uranium = 0.25, /datum/reagent/iodine = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
 

--- a/modular_lumos/code/modules/hydroponics/plant_genes.dm
+++ b/modular_lumos/code/modules/hydroponics/plant_genes.dm
@@ -1,0 +1,11 @@
+/datum/plant_gene/trait/noreact
+	// Makes plant reagents not react until squashed.
+	name = "Separated Chemicals"
+
+/datum/plant_gene/trait/noreact/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
+	..()
+	ENABLE_BITFIELD(G.reagents.reagents_holder_flags, NO_REACT)
+
+/datum/plant_gene/trait/noreact/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+	DISABLE_BITFIELD(G.reagents.reagents_holder_flags, NO_REACT)
+	G.reagents.handle_reactions()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3839,6 +3839,7 @@
 #include "modular_citadel\code\modules\vectorcrafts\vectorvariants.dm"
 #include "modular_lumos\code\modules\client\loadout\__donator.dm"
 #include "modular_lumos\code\modules\custom_loadout\custom_items.dm"
+#include "modular_lumos\code\modules\hydroponics\plant_genes.dm"
 #include "modular_nostra\code\__DEFINES\actionspeed_modifiers.dm"
 #include "modular_nostra\code\__DEFINES\construction.dm"
 #include "modular_nostra\code\__DEFINES\DNA.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
 Adds the Separated Chems trait back into botany via Glow Berries.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More creativity (explosive weapons) in botany.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Separated Chems as a plant trait
tweak: Added Separated Chems gene to glow berries
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
