### PR TITLE
Horny-B-Gone

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -18262,7 +18262,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/vending/kink,
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "aQY" = (
@@ -56580,10 +56580,6 @@
 	},
 /turf/open/floor/wood/wood_diagonal,
 /area/maintenance/port/fore)
-"kqy" = (
-/obj/machinery/gear_painter,
-/turf/open/floor/plasteel,
-/area/commons/fitness)
 "kqI" = (
 /obj/structure/window,
 /turf/open/floor/wood,
@@ -57075,7 +57071,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "lsk" = (
-/obj/machinery/vending/kink,
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/commons/fitness)
 "ltK" = (
@@ -58731,7 +58727,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "pqR" = (
@@ -98706,7 +98701,7 @@ awB
 att
 azh
 fHG
-kqy
+fHG
 kxf
 ufD
 alP

--- a/_maps/map_files/KiloStation/KiloStation_Lumos.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_Lumos.dmm
@@ -48108,7 +48108,7 @@
 "bGE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/vending/snack/random,
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "bGG" = (
@@ -49256,7 +49256,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/vending/kink,
+/obj/machinery/vending/clothing,
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "bJb" = (
@@ -65345,10 +65345,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/vending/clothing,
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
+/obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "cls" = (
@@ -65484,7 +65484,7 @@
 	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/gear_painter,
+/obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "clG" = (

--- a/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
@@ -52433,7 +52433,6 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/cryopod)
 "fxX" = (
-/obj/machinery/vending/kink,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -52444,6 +52443,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/wardrobe/black,
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "fxY" = (
@@ -56928,7 +56928,6 @@
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "ipj" = (
-/obj/structure/closet/wardrobe/white,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -56939,6 +56938,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "ipm" = (
@@ -63590,7 +63590,6 @@
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
 "mig" = (
-/obj/machinery/vending/clothing,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -63601,6 +63600,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/wardrobe/grey,
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "miq" = (
@@ -64365,10 +64365,6 @@
 /area/engineering/gravity_generator)
 "mER" = (
 /obj/structure/table,
-/obj/item/clothing/head/soft/grey{
-	pixel_x = -2;
-	pixel_y = 3
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -67146,7 +67142,6 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "out" = (
-/obj/structure/closet/wardrobe/black,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -67157,6 +67152,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/vending/clothing,
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "ouC" = (
@@ -72835,7 +72831,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/machinery/gear_painter,
+/obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "rLH" = (
@@ -80270,7 +80266,6 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "wsX" = (
-/obj/structure/closet/wardrobe/grey,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -80286,6 +80281,11 @@
 	},
 /obj/structure/sign/poster/official/fashion{
 	pixel_y = -32
+	},
+/obj/structure/table,
+/obj/item/clothing/head/soft/grey{
+	pixel_x = -2;
+	pixel_y = 3
 	},
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)

--- a/_maps/map_files/OmegaStation/OmegaStation2deck_Lumos.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation2deck_Lumos.dmm
@@ -2459,8 +2459,8 @@
 /turf/open/floor/plating,
 /area/asteroid/nearstation)
 "jV" = (
-/obj/structure/reagent_dispensers/keg/aphro/strong,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/kink,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/bar)
 "jW" = (
@@ -5626,7 +5626,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/oldomega/HigherHall)
 "wP" = (
-/obj/machinery/vending/kink,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -8360,7 +8359,6 @@
 "HI" = (
 /obj/structure/table/wood,
 /obj/item/melee/flyswatter,
-/obj/item/clothing/shoes/jackboots,
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
@@ -11792,18 +11790,13 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/oldomega/HigherHall)
 "WM" = (
-/obj/item/restraints/handcuffs/fake/kinky,
 /obj/structure/table/wood,
-/obj/item/dildo/random,
-/obj/item/dildo/random,
-/obj/item/restraints/handcuffs/fake/kinky,
-/obj/item/electropack/shockcollar,
-/obj/item/assembly/signaler,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
+/obj/item/clothing/shoes/jackboots,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
 "WP" = (

--- a/_maps/map_files/OmegaStation/OmegaStation_Lumos.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation_Lumos.dmm
@@ -31650,6 +31650,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
+/obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/maintenance/port)
 "bbf" = (
@@ -36671,7 +36672,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/vending/kink,
+/obj/machinery/computer/slot_machine,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bjS" = (

--- a/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
@@ -462,15 +462,15 @@
 /turf/open/floor/plasteel/yellowsiding/corner,
 /area/commons/fitness/pool)
 "abd" = (
-/obj/structure/closet/lasertag/red,
+/obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "abe" = (
-/obj/machinery/vending/kink,
 /obj/machinery/status_display/evac{
 	pixel_x = 32;
 	pixel_y = 32
 	},
+/obj/structure/closet/lasertag/blue,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "abf" = (
@@ -487,14 +487,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/closet/lasertag/blue,
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "abi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "abj" = (
@@ -4658,7 +4657,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "alb" = (
-/obj/structure/reagent_dispensers/keg/aphro,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
 "alc" = (
@@ -9872,10 +9870,10 @@
 /turf/open/floor/plating,
 /area/commons/fitness/recreation)
 "awB" = (
-/obj/machinery/vending/clothing,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/closet/lasertag/red,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},

--- a/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_Lumos.dmm
@@ -17844,7 +17844,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
 "gEq" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/vending/kink,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "gEz" = (
@@ -27040,7 +27040,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/vending/kink,
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "kJO" = (
@@ -32143,14 +32145,9 @@
 /turf/closed/wall/mineral/wood,
 /area/maintenance/bar)
 "nee" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-05"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "nek" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -92169,7 +92166,7 @@ uBa
 uBa
 kop
 oeV
-nee
+mPw
 tif
 bBL
 cvH
@@ -101837,7 +101834,7 @@ asn
 clf
 aFQ
 asn
-aFQ
+nee
 qKJ
 hLE
 aSE


### PR DESCRIPTION
## About The Pull Request

Removes public Kink vendors from all maps currently in use.

## Why It's Good For The Game

Horny people who lack imagination will have to grow a braincell to acquire their toys now.

## Changelog
del: Removed public Kink vendors on Box, Pubby, Omega, Kilo, Meta, Delta and Snaxi.
/:cl:

