### PR TITLE
Captains ID spawn changes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -26953,6 +26953,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "bmA" = (

--- a/_maps/map_files/DIYstation/DIYstation.dmm
+++ b/_maps/map_files/DIYstation/DIYstation.dmm
@@ -6968,6 +6968,7 @@
 /obj/structure/closet/crate/bin{
 	pixel_y = 6
 	},
+/obj/item/card/id/captains_spare,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/shuttle/bridge)
 "Mj" = (

--- a/_maps/map_files/Deltastation/DeltaStation2_Lumos.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Lumos.dmm
@@ -65596,6 +65596,7 @@
 /area/command/heads_quarters/captain/private)
 "cgy" = (
 /obj/structure/dresser,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "cgz" = (

--- a/_maps/map_files/KiloStation/KiloStation_Lumos.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_Lumos.dmm
@@ -9503,6 +9503,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/item/card/id/captains_spare,
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/captain)
 "arW" = (

--- a/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
@@ -78963,6 +78963,7 @@
 	pixel_x = 6;
 	pixel_y = 28
 	},
+/obj/item/card/id/captains_spare,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "vDS" = (

--- a/_maps/map_files/OmegaStation/OmegaStation_Lumos.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation_Lumos.dmm
@@ -3410,6 +3410,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/item/card/id/captains_spare,
 /turf/open/floor/plasteel/grimy,
 /area/command/heads_quarters/captain/private)
 "afI" = (

--- a/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
@@ -10369,6 +10369,7 @@
 /area/hallway/primary/fore)
 "axN" = (
 /obj/structure/dresser,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/plasteel/grimy,
 /area/command/heads_quarters/captain/private)
 "axO" = (


### PR DESCRIPTION
## About The Pull Request

Captains spare ID set to spawn in his office. 

## Why It's Good For The Game

People 

## Changelog
add: Added a spawn for the Captains spare ID on Box, Omega, Kilo, Pubby, Meta, Delta, DIY.
/:cl:
