### PR TITLE
Spare ID spawns

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_nostra.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_nostra.dmm
@@ -26953,6 +26953,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "bmA" = (
@@ -39940,6 +39941,9 @@
 /area/science/misc_lab)
 "bQV" = (
 /obj/machinery/nanite_program_hub,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/science/nanite)
 "bQW" = (

--- a/_maps/map_files/Deltastation/DeltaStation2_nostra.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_nostra.dmm
@@ -52675,6 +52675,7 @@
 "bMM" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/plasteel/grimy,
 /area/command/heads_quarters/captain)
 "bMN" = (

--- a/_maps/map_files/KiloStation/KiloStation_nostra.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_nostra.dmm
@@ -46167,6 +46167,7 @@
 "bDc" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "bDd" = (

--- a/_maps/map_files/MetaStation/MetaStation_nostra.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_nostra.dmm
@@ -66780,6 +66780,7 @@
 	pixel_x = -30;
 	pixel_y = 1
 	},
+/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "ojC" = (

--- a/_maps/map_files/OmegaStation/OmegaStation_nostra.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation_nostra.dmm
@@ -3410,6 +3410,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/item/card/id/captains_spare,
 /turf/open/floor/plasteel/grimy,
 /area/command/heads_quarters/captain/private)
 "afI" = (

--- a/_maps/map_files/PubbyStation/PubbyStation_nostra.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_nostra.dmm
@@ -10369,6 +10369,7 @@
 /area/hallway/primary/fore)
 "axN" = (
 /obj/structure/dresser,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/plasteel/grimy,
 /area/command/heads_quarters/captain/private)
 "axO" = (


### PR DESCRIPTION
## About The Pull Request

Captains spare ID set to spawn in his office.

## Why It's Good For The Game

Society

## Changelog
:cl:
add: Added a spawn for the Captains spare ID on Box, Omega, Kilo, Pubby, Mete and Delta (Nost).
/:cl:
