### PR TITLE
Horny-B-Gone (Nost maps)

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_nostra.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_nostra.dmm
@@ -56598,10 +56598,6 @@
 	},
 /turf/open/floor/wood/wood_diagonal,
 /area/maintenance/port/fore)
-"kqy" = (
-/obj/machinery/gear_painter,
-/turf/open/floor/plasteel,
-/area/commons/fitness)
 "kqI" = (
 /obj/structure/window,
 /turf/open/floor/wood,
@@ -57086,7 +57082,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "lsk" = (
-/obj/machinery/vending/kink,
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/commons/fitness)
 "ltK" = (
@@ -98717,7 +98713,7 @@ awB
 att
 azh
 fHG
-kqy
+fHG
 kxf
 ufD
 alP

--- a/_maps/map_files/KiloStation/KiloStation_nostra.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_nostra.dmm
@@ -49248,15 +49248,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bIZ" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/vending/kink,
-/turf/open/floor/plasteel/dark,
-/area/commons/locker)
 "bJb" = (
 /obj/item/target/clown,
 /obj/structure/window/reinforced{
@@ -109581,7 +109572,7 @@ bAN
 bAN
 boR
 aMF
-bIZ
+aMF
 btS
 bwa
 bxS

--- a/_maps/map_files/MetaStation/MetaStation_nostra.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_nostra.dmm
@@ -52433,7 +52433,6 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/cryopod)
 "fxX" = (
-/obj/machinery/vending/kink,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -52444,6 +52443,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/vending/clothing,
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "fxY" = (
@@ -63587,7 +63587,6 @@
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
 "mig" = (
-/obj/machinery/vending/clothing,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -63598,6 +63597,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "miq" = (
@@ -72833,7 +72833,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/machinery/gear_painter,
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "rLH" = (

--- a/_maps/map_files/OmegaStation/OmegaStation2deck_nostra.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation2deck_nostra.dmm
@@ -760,7 +760,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/closet/firecloset,
+/obj/machinery/vending/kink,
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "cW" = (
@@ -2458,11 +2458,6 @@
 	},
 /turf/open/floor/plating,
 /area/asteroid/nearstation)
-"jV" = (
-/obj/structure/reagent_dispensers/keg/aphro/strong,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/bar)
 "jW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -5626,7 +5621,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/oldomega/HigherHall)
 "wP" = (
-/obj/machinery/vending/kink,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -8360,7 +8354,6 @@
 "HI" = (
 /obj/structure/table/wood,
 /obj/item/melee/flyswatter,
-/obj/item/clothing/shoes/jackboots,
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
@@ -11792,18 +11785,13 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/oldomega/HigherHall)
 "WM" = (
-/obj/item/restraints/handcuffs/fake/kinky,
 /obj/structure/table/wood,
-/obj/item/dildo/random,
-/obj/item/dildo/random,
-/obj/item/restraints/handcuffs/fake/kinky,
-/obj/item/electropack/shockcollar,
-/obj/item/assembly/signaler,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
+/obj/item/clothing/shoes/jackboots,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
 "WP" = (
@@ -49211,7 +49199,7 @@ QP
 bM
 fo
 iP
-jV
+hz
 Qy
 gt
 Fb

--- a/_maps/map_files/OmegaStation/OmegaStation_nostra.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation_nostra.dmm
@@ -36678,7 +36678,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/vending/kink,
+/obj/machinery/computer/slot_machine,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bjS" = (

--- a/_maps/map_files/PubbyStation/PubbyStation_nostra.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_nostra.dmm
@@ -4658,7 +4658,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "alb" = (
-/obj/structure/reagent_dispensers/keg/aphro,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
 "alc" = (

--- a/_maps/map_files/PubbyStation/PubbyStation_nostra.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_nostra.dmm
@@ -466,11 +466,11 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "abe" = (
-/obj/machinery/vending/kink,
 /obj/machinery/status_display/evac{
 	pixel_x = 32;
 	pixel_y = 32
 	},
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "abf" = (
@@ -494,7 +494,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/gear_painter,
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "abj" = (


### PR DESCRIPTION
## About The Pull Request

Removes kink vendors from public places on the stations stated below

## Why It's Good For The Game

No horny vendors in public

## Changelog
del: Removed public Kink vendors on Box, Omega, Kilo, Pubby, Meta.
/:cl:

