### PR TITLE
Loadout Changes

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -217,7 +217,7 @@
 /obj/item/choice_beacon/box/carpet //donator carpet beacon
 	name = "choice box (carpet)"
 	desc = "Contains 50 of a selected carpet inside!"
-	var/static/list/carpet_list = list(/obj/item/stack/tile/carpet/black/fifty = "Black Carpet",
+	var/static/list/carpet_list = list("Black Carpet" = /obj/item/stack/tile/carpet/black/fifty,
 		"Black & Red Carpet" = /obj/item/stack/tile/carpet/blackred/fifty,
 		"Monochrome Carpet" = /obj/item/stack/tile/carpet/monochrome/fifty,
 		"Blue Carpet" = /obj/item/stack/tile/carpet/blue/fifty,

--- a/modular_lumos/code/modules/client/loadout/accessories.dm
+++ b/modular_lumos/code/modules/client/loadout/accessories.dm
@@ -2,21 +2,22 @@
 	category = LOADOUT_CATEGORY_GLOVES
 	slot = SLOT_GLOVES
 
-/datum/gear/accessories/ring/goldring
-	name = "A gold ring"
-	path = /obj/item/clothing/accessory/ring
-	cost = 2
-
 /datum/gear/accessories/ring/silverring
 	name = "A silver ring"
 	path = /obj/item/clothing/accessory/ring/silver
 	cost = 2
 
+/datum/gear/accessories/ring/goldring
+	name = "A gold ring"
+	path = /obj/item/clothing/accessory/ring
+	cost = 4
+
 /datum/gear/accessories/ring/diamondring
 	name = "A diamond ring"
 	path = /obj/item/clothing/accessory/ring/diamond
-	cost = 4
+	cost = 6
 
 /datum/gear/accessories/ring/customring
 	name = "A ring, renameable"
 	path = /obj/item/clothing/accessory/ring/custom
+	cost = 2

--- a/modular_lumos/code/modules/client/loadout/backpack.dm
+++ b/modular_lumos/code/modules/client/loadout/backpack.dm
@@ -6,6 +6,7 @@
 /datum/gear/backpack/plushbox
 	name = "Plushie Choice Box"
 	path = /obj/item/choice_beacon/box/plushie
+	cost = 4
 	subcategory = LOADOUT_SUBCATEGORY_BACKPACK_TOYS
 
 /datum/gear/backpack/tennis
@@ -13,102 +14,25 @@
 	path = /obj/item/toy/fluff/tennis_poly
 	subcategory = LOADOUT_SUBCATEGORY_BACKPACK_TOYS
 
-/datum/gear/backpack/tennis/red
-	name = "Red Tennis Ball"
-	path = /obj/item/toy/fluff/tennis_poly/red
-
-/datum/gear/backpack/tennis/yellow
-	name = "Yellow Tennis Ball"
-	path = /obj/item/toy/fluff/tennis_poly/yellow
-
-/datum/gear/backpack/tennis/green
-	name = "Green Tennis Ball"
-	path = /obj/item/toy/fluff/tennis_poly/green
-
-/datum/gear/backpack/tennis/cyan
-	name = "Cyan Tennis Ball"
-	path = /obj/item/toy/fluff/tennis_poly/cyan
-
-/datum/gear/backpack/tennis/blue
-	name = "Blue Tennis Ball"
-	path = /obj/item/toy/fluff/tennis_poly/blue
-
-/datum/gear/backpack/tennis/purple
-	name = "Purple Tennis Ball"
-	path = /obj/item/toy/fluff/tennis_poly/purple
-
-/datum/gear/backpack/tennis/tri
-	name = "Tri-color Polychromic Tennis Ball"
-	path = /obj/item/toy/fluff/tennis_poly/tri
-	cost = 3
-
 /datum/gear/backpack/tennis/tri/squeak
-	name = "Squeakable Tri-color Polychromic Tennis Ball"
+	name = "Squeakable Tri-color Tennis Ball"
 	path = /obj/item/toy/fluff/tennis_poly/tri/squeak
-	cost = 6
+	cost = 3
 
 /datum/gear/backpack/bone
 	name = "Polychromic Bone"
 	path = /obj/item/toy/fluff/bone_poly
 	subcategory = LOADOUT_SUBCATEGORY_BACKPACK_TOYS
 
-/datum/gear/backpack/bone/red
-	name = "Red Polychromic Bone"
-	path = /obj/item/toy/fluff/bone_poly/red
-
-/datum/gear/backpack/bone/yellow
-	name = "Yellow Polychromic Bone"
-	path = /obj/item/toy/fluff/bone_poly/yellow
-
-/datum/gear/backpack/bone/green
-	name = "Green Polychromic Bone"
-	path = /obj/item/toy/fluff/bone_poly/green
-
-/datum/gear/backpack/bone/cyan
-	name = "Cyan Polychromic Bone"
-	path = /obj/item/toy/fluff/bone_poly/cyan
-
-/datum/gear/backpack/bone/blue
-	name = "Blue Polychromic Bone"
-	path = /obj/item/toy/fluff/bone_poly/blue
-
-/datum/gear/backpack/bone/purple
-	name = "Purple Polychromic Bone"
-	path = /obj/item/toy/fluff/bone_poly/purple
-
 /datum/gear/backpack/bone/squeak
 	name = "Squeakable Polychromic Bone"
 	path = /obj/item/toy/fluff/bone_poly/squeak
-	cost = 6
+	cost = 3
 
 /datum/gear/backpack/frisbee
 	name = "Polychromic Frisbee"
 	path = /obj/item/toy/fluff/frisbee_poly
 	subcategory = LOADOUT_SUBCATEGORY_BACKPACK_TOYS
-
-/datum/gear/backpack/frisbee/red
-	name = "Red Polychromic Frisbee"
-	path = /obj/item/toy/fluff/frisbee_poly/red
-
-/datum/gear/backpack/frisbee/yellow
-	name = "Yellow Polychromic Frisbee"
-	path = /obj/item/toy/fluff/frisbee_poly/yellow
-
-/datum/gear/backpack/frisbee/green
-	name = "Green Polychromic Frisbee"
-	path = /obj/item/toy/fluff/frisbee_poly/green
-
-/datum/gear/backpack/frisbee/cyan
-	name = "Cyan Polychromic Frisbee"
-	path = /obj/item/toy/fluff/frisbee_poly/cyan
-
-/datum/gear/backpack/frisbee/blue
-	name = "Blue Polychromic Frisbee"
-	path = /obj/item/toy/fluff/frisbee_poly/blue
-
-/datum/gear/backpack/frisbee/purple
-	name = "Purple Polychromic Frisbee"
-	path = /obj/item/toy/fluff/frisbee_poly/purple
 
 /datum/gear/backpack/dildo
 	name = "Customizable dildo"
@@ -147,6 +71,25 @@
 	path = /obj/item/pen/fountain
 	cost = 2
 
+/datum/gear/backpack/necklace//this is here because loadout doesn't support proper accessories
+	name = "A renameable necklace"
+	path = /obj/item/clothing/accessory/necklace
+
+/datum/gear/backpack/ringbox_silver
+	name = "A silver ring box"
+	path = /obj/item/storage/fancy/ringbox/silver
+	cost = 2
+
+/datum/gear/backpack/ringbox_gold
+	name = "A gold ring box"
+	path = /obj/item/storage/fancy/ringbox
+	cost = 4
+
+/datum/gear/backpack/ringbox_diamond
+	name = "A diamond ring box"
+	path = /obj/item/storage/fancy/ringbox/diamond
+	cost = 6
+
 /datum/gear/backpack/modular_tablet
 	name = "A modular tablet"
 	path = /obj/item/modular_computer/tablet/preset/cheap/
@@ -157,21 +100,22 @@
 	path = /obj/item/modular_computer/laptop/preset/civilian
 	cost = 7
 
-/datum/gear/backpack/ringbox_gold
-	name = "A gold ring box"
-	path = /obj/item/storage/fancy/ringbox
-	cost = 3
+//Lumos change
 
-/datum/gear/backpack/ringbox_silver
-	name = "A silver ring box"
-	path = /obj/item/storage/fancy/ringbox/silver
-	cost = 3
-
-/datum/gear/backpack/ringbox_diamond
-	name = "A diamond ring box"
-	path = /obj/item/storage/fancy/ringbox/diamond
+/datum/gear/backpack/choice_beacon/box/carpet
+	name = "A carpet beacon"
+	path = /obj/item/choice_beacon/box/carpet
 	cost = 5
 
-/datum/gear/backpack/necklace//this is here because loadout doesn't support proper accessories
-	name = "A renameable necklace"
-	path = /obj/item/clothing/accessory/necklace
+/datum/gear/backpack/choice_beacon/pet
+	name = "A pet beacon"
+	path = /obj/item/choice_beacon/pet
+	cost = 7
+
+
+
+
+
+
+
+

--- a/modular_lumos/code/modules/client/loadout/hands.dm
+++ b/modular_lumos/code/modules/client/loadout/hands.dm
@@ -71,3 +71,8 @@
 	description = "Everything the electric razor does plus getting executed by security for slitting someone's throat with this."
 	path = /obj/item/razor/straightrazor
 	cost = 8
+
+/datum/gear/hands/skateboard
+	name = "Skateboard"
+	path = /obj/item/melee/skateboard
+	cost = 10

--- a/modular_lumos/code/modules/client/loadout/hands.dm
+++ b/modular_lumos/code/modules/client/loadout/hands.dm
@@ -6,10 +6,6 @@
 	name = "Cane"
 	path = /obj/item/cane
 
-/datum/gear/hands/cigarettes
-	name = "Cigarette pack"
-	path = /obj/item/storage/fancy/cigarettes
-
 /datum/gear/hands/dice
 	name = "Dice bag"
 	path = /obj/item/storage/dice
@@ -17,14 +13,6 @@
 /datum/gear/hands/eightball
 	name = "Magic eightball"
 	path = /obj/item/toy/eightball
-
-/datum/gear/hands/matches
-	name = "Matchbox"
-	path = /obj/item/storage/box/matches
-
-/datum/gear/hands/cheaplighter
-	name = "Cheap lighter"
-	path = /obj/item/lighter/greyscale
 
 /datum/gear/hands/cards
 	name = "Playing cards"
@@ -43,10 +31,30 @@
 	path = /obj/item/reagent_containers/food/drinks/flask
 	cost = 2
 
+/datum/gear/hands/matches
+	name = "Matchbox"
+	path = /obj/item/storage/box/matches
+
+/datum/gear/hands/cheaplighter
+	name = "Cheap lighter"
+	path = /obj/item/lighter/greyscale
+
 /datum/gear/hands/zippolighter
 	name = "Zippo Lighter"
 	path = /obj/item/lighter
 	cost = 2
+
+/datum/gear/hands/cigpack_robust
+	name = "Robust packet"
+	path = /obj/item/storage/fancy/cigarettes/cigpack_robust
+
+/datum/gear/hands/dromedaryco
+	name = "DromedaryCo packet"
+	path = /obj/item/storage/fancy/cigarettes/dromedaryco
+
+/datum/gear/hands/cigpack_uplift
+	name = "Uplift Smooth packet"
+	path = /obj/item/storage/fancy/cigarettes/cigpack_uplift
 
 /datum/gear/hands/cigar
 	name = "Cigar"

--- a/modular_lumos/code/modules/vending/wardrobes.dm
+++ b/modular_lumos/code/modules/vending/wardrobes.dm
@@ -1,5 +1,0 @@
-/obj/machinery/vending/wardrobe/sec_wardrobe/Initialize(mapload)
-	products[/obj/item/clothing/shoes/jackboots/puttee] = 5
-	for(var/item in subtypesof(/obj/item/clothing/head/helmet/brodie))
-		products[item] = 5
-	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4189,6 +4189,5 @@
 #include "modular_lumos\code\modules\vectorcrafts\vectorvariants.dm"
 #include "modular_lumos\code\modules\vending\autodrobe.dm"
 #include "modular_lumos\code\modules\vending\clothesmate.dm"
-#include "modular_lumos\code\modules\vending\wardrobes.dm"
 #include "tools\Redirector\textprocs.dm"
 // END_INCLUDE


### PR DESCRIPTION
## About The Pull Request

Tweaks for some loadout options, more info in the changelog.

## Why It's Good For The Game

Variety, adds some former donator items from Citadel that would've went unused to the loadout.

## A Port?

No.

## Changelog
:cl:
add: added carpet beacon, pet beacon and skateboard to loadout
del: removed WW1 stuff from sec vendors, now loadout only
del: removed surplus toys from loadout
tweak: adjusted prices for backpack loadout items
/:cl: