### PR TITLE
Sharp screwdrivers 

### DIFF
--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -17,6 +17,7 @@
 	custom_materials = list(/datum/material/iron=75)
 	attack_verb = list("stabbed")
 	hitsound = 'sound/weapons/bladeslice.ogg'
+	sharpness = SHARP_POINTY
 	usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
 	tool_behaviour = TOOL_SCREWDRIVER
 	toolspeed = 1


### PR DESCRIPTION
## About The Pull Request

Gives screwdrivers a sharpness variable so they can cut pizza (yes, thats the only reason for this PR, Lumos 1 screwdrivers rock), also fixes a sharpness typo in the fish_tools.dm Fajeet ported.

## Why It's Good For The Game

Screwdrivers are too underpowered right now. 

## A Port?

No.

## Changelog
:cl:
tweak: tweaked screwdriver.dm
tweak: tweaked fish_tools.dm
/:cl: