### PR TITLE
Paramedic Oxygen Supply

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Lumos.dmm
@@ -33833,6 +33833,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "bOw" = (
@@ -45569,6 +45570,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "czU" = (

--- a/_maps/map_files/Deltastation/DeltaStation2_Lumos.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Lumos.dmm
@@ -25906,9 +25906,7 @@
 	desc = "A bed for carp.";
 	name = "Jerry's bed"
 	},
-/mob/living/simple_animal/hostile/carp/cargo{
-	icon_state = "cargo_carp"
-	},
+/mob/living/simple_animal/hostile/carp/cargo,
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "aVV" = (
@@ -107760,6 +107758,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "dBt" = (
@@ -109402,6 +109401,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "dEh" = (

--- a/_maps/map_files/KiloStation/KiloStation_Lumos.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_Lumos.dmm
@@ -18653,6 +18653,7 @@
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/tile/blue/fullcorner,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/paramedic)
 "aPX" = (
@@ -62465,6 +62466,7 @@
 /obj/effect/turf_decal/tile/blue/fullcorner{
 	dir = 4
 	},
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/paramedic)
 "eDs" = (

--- a/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Lumos.dmm
@@ -13102,9 +13102,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aWV" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aWW" = (
@@ -34805,6 +34803,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "cxf" = (
@@ -34834,6 +34833,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "cxh" = (
@@ -72273,7 +72273,6 @@
 /area/commons/fitness/recreation)
 "rta" = (
 /obj/machinery/door/airlock/external{
-	dir = 2;
 	name = "Public Mining Dock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/_maps/map_files/OmegaStation/OmegaStation_Lumos.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation_Lumos.dmm
@@ -8709,6 +8709,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/suit_storage_unit/paramedic,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "eib" = (
@@ -31457,6 +31458,7 @@
 	dir = 4
 	},
 /obj/machinery/suit_storage_unit/paramedic,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "oqY" = (

--- a/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
@@ -24483,8 +24483,8 @@
 /area/medical/paramedic)
 "bny" = (
 /obj/machinery/suit_storage_unit/paramedic,
-/obj/item/tank/internals/oxygen/yellow,
 /obj/effect/turf_decal/tile/blue/fulltile,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "bnz" = (


### PR DESCRIPTION
## About The Pull Request

Since I cant get the oxy tanks to spawn in their locker, I've made them spawn on top of the suit storage on every map we use minus Snaxi which already has a tank dispenser for paramedics.

## Why It's Good For The Game

Paramedics can do their job more efficiently without needing to beg engineering for a larger oxygen tank roundstart or depend on standard small one everyone spawns with.

## A Port?

No.

## Changelog
:cl:
add: added oxygen tanks that spawn on para suit storage
/:cl: