### PR TITLE
Fake Railings

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skelter.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skelter.dmm
@@ -443,7 +443,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/service/cafeteria)
 "bh" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1;
 	icon_state = "railing"
 	},
@@ -454,7 +454,7 @@
 /area/ruin/space/has_grav/skelter/engine/upper)
 "bi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1;
 	icon_state = "railing"
 	},
@@ -464,7 +464,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skelter/engine/upper)
 "bj" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 5;
 	icon_state = "railing"
 	},
@@ -581,7 +581,7 @@
 /turf/closed/wall/mineral/titanium/interior,
 /area/ruin/space/has_grav/skelter)
 "by" = (
-/obj/structure/fluff/railing,
+/obj/structure/railing,
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
@@ -616,14 +616,14 @@
 /area/service/cafeteria)
 "bC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/fluff/railing,
+/obj/structure/railing,
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skelter/engine/upper)
 "bD" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 6;
 	icon_state = "railing"
 	},
@@ -2888,7 +2888,7 @@
 /area/ruin/space/has_grav/skelter/storage)
 "gQ" = (
 /obj/machinery/shieldgen,
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 6;
 	icon_state = "railing"
 	},
@@ -2944,7 +2944,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skelter/forehall)
 "gW" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1;
 	icon_state = "railing"
 	},
@@ -2955,7 +2955,7 @@
 /area/ruin/space/has_grav/skelter/engine/lower)
 "gX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1;
 	icon_state = "railing"
 	},
@@ -2965,7 +2965,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skelter/engine/lower)
 "gY" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 5;
 	icon_state = "railing"
 	},
@@ -3158,14 +3158,14 @@
 /area/ruin/space/has_grav/skelter/shields)
 "hq" = (
 /obj/machinery/shieldgen,
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 9;
 	icon_state = "railing"
 	},
 /turf/open/floor/circuit/airless,
 /area/ruin/space/has_grav/skelter/shields)
 "hr" = (
-/obj/structure/fluff/railing,
+/obj/structure/railing,
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
@@ -3173,14 +3173,14 @@
 /area/ruin/space/has_grav/skelter/engine/lower)
 "hs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/fluff/railing,
+/obj/structure/railing,
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skelter/engine/lower)
 "ht" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 6;
 	icon_state = "railing"
 	},
@@ -3345,7 +3345,7 @@
 /area/ruin/space/has_grav/skelter/shields)
 "hO" = (
 /obj/machinery/shieldgen,
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 8;
 	icon_state = "railing"
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
@@ -10756,7 +10756,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue/fulltile,
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/hop)
 "aCW" = (
 /obj/structure/cable{
@@ -52504,6 +52504,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue/fulltile,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "mzl" = (

--- a/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Lumos.dmm
@@ -14493,16 +14493,16 @@
 	name = "disposal conveyor"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/fluff/railing,
+/obj/structure/railing,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
 "aMG" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/fluff/railing,
+/obj/structure/railing,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
 "aMH" = (
-/obj/structure/fluff/railing/corner{
+/obj/structure/railing/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -14975,7 +14975,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15425,7 +15425,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15776,7 +15776,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15797,7 +15797,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16306,7 +16306,7 @@
 	dir = 1
 	},
 /obj/structure/closet/crate,
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16319,7 +16319,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/xeno_spawn,
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16332,7 +16332,7 @@
 	dir = 4
 	},
 /obj/item/trash/can,
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16345,7 +16345,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16359,7 +16359,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/fluff/railing/corner{
+/obj/structure/railing/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16675,7 +16675,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aSm" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -16690,7 +16690,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/Snaxi/Snaxi.dmm
+++ b/_maps/map_files/Snaxi/Snaxi.dmm
@@ -9544,7 +9544,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "axN" = (
-/obj/structure/fluff/railing,
+/obj/structure/railing,
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors)
 "ayk" = (
@@ -9648,7 +9648,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "ayC" = (
-/obj/structure/fluff/railing/corner{
+/obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/open/openspace/icemoon,
@@ -9789,7 +9789,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "azH" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 4
 	},
 /turf/open/openspace/icemoon,
@@ -10026,7 +10026,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "aCr" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 8
 	},
 /turf/open/openspace/icemoon,
@@ -10254,7 +10254,7 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
 "aEG" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 10
 	},
 /turf/open/openspace/icemoon,
@@ -10425,7 +10425,7 @@
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "aHK" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 6
 	},
 /turf/open/openspace/icemoon,
@@ -15918,7 +15918,7 @@
 /turf/open/floor/pod/dark,
 /area/maintenance/starboard)
 "cVa" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 9
 	},
 /turf/open/openspace/icemoon,
@@ -16897,7 +16897,7 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "dDC" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1
 	},
 /turf/open/openspace/icemoon,
@@ -16969,7 +16969,7 @@
 /turf/closed/wall,
 /area/cargo/qm)
 "dFJ" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 5
 	},
 /turf/open/openspace/icemoon,
@@ -28446,7 +28446,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "lgg" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 5
 	},
 /turf/open/openspace/icemoon,
@@ -29471,7 +29471,7 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/exit/departure_lounge)
 "lQJ" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 9
 	},
 /turf/open/openspace/icemoon,
@@ -33894,7 +33894,7 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "oGZ" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 6
 	},
 /turf/open/openspace/icemoon,
@@ -37696,7 +37696,7 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "qZb" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 10
 	},
 /turf/open/openspace/icemoon,
@@ -40478,7 +40478,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "sTq" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1
 	},
 /turf/open/openspace/icemoon,

--- a/_maps/map_files/Snaxi/Snaxi_nostra.dmm
+++ b/_maps/map_files/Snaxi/Snaxi_nostra.dmm
@@ -5429,7 +5429,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bum" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 8
 	},
 /turf/open/openspace/icemoon,
@@ -26789,7 +26789,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/office)
 "lZb" = (
-/obj/structure/fluff/railing/corner{
+/obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/open/openspace/icemoon,
@@ -35223,7 +35223,7 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "qyE" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 9
 	},
 /turf/open/openspace/icemoon,
@@ -35856,7 +35856,7 @@
 /turf/open/floor/carpet,
 /area/service/chapel/office)
 "qPM" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 4
 	},
 /turf/open/openspace/icemoon,
@@ -36617,7 +36617,7 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "rka" = (
-/obj/structure/fluff/railing,
+/obj/structure/railing,
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors)
 "rkd" = (
@@ -39459,7 +39459,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "sTq" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 10
 	},
 /turf/open/openspace/icemoon,
@@ -41623,7 +41623,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "tWo" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 1
 	},
 /turf/open/openspace/icemoon,
@@ -46348,7 +46348,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "wrI" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 5
 	},
 /turf/open/openspace/icemoon,
@@ -46377,7 +46377,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmospherics_engine)
 "wsT" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	dir = 6
 	},
 /turf/open/openspace/icemoon,

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -199,19 +199,6 @@
 	density = TRUE
 	deconstructible = FALSE
 
-/obj/structure/fluff/railing
-	name = "railing"
-	desc = "Basic railing meant to protect idiots like you from falling."
-	icon = 'icons/obj/fluff.dmi'
-	icon_state = "railing"
-	density = TRUE
-	anchored = TRUE
-	deconstructible = FALSE
-
-/obj/structure/fluff/railing/corner
-	icon_state = "railing_corner"
-	density = FALSE
-
 /obj/structure/fluff/beach_towel
 	name = "beach towel"
 	desc = "A towel decorated in various beach-themed designs."

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -223,8 +223,8 @@
 			L.Move(landing_turf, vehicle_target.dir)
 			passtable_off(L, VEHICLE_TRAIT)
 			V.pass_flags &= ~PASSTABLE
-		if((locate(/obj/structure/table) in V.loc.contents) || (locate(/obj/structure/fluff/railing) in V.loc.contents))
-			if(locate(/obj/structure/fluff/railing) in V.loc.contents)
+		if((locate(/obj/structure/table) in V.loc.contents) || (locate(/obj/structure/railing) in V.loc.contents))
+			if(locate(/obj/structure/railing) in V.loc.contents)
 				L.client.give_award(/datum/award/achievement/misc/tram_surfer, L)
 			V.grinding = TRUE
 			V.icon_state = "[V.board_icon]-grind"


### PR DESCRIPTION
## About The Pull Request

Removes the fake fluff railings which take up a whole tile and are objectively worse than their non-fluff version.

## Why It's Good For The Game

It removes an unnecessary structure.

## A Port?

No.

## Changelog
:cl:
del: removed fluff railings from fluff.dm
tweak: replaced said railings in existing maps with the actual railings
/:cl: